### PR TITLE
Upgrade mongodb log version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "which": "^1.0.5",
     "keepup": "^0.0.4",
     "mongodb-bridge": "^0.0.5",
-    "mongodb-log": "^0.1.0",
+    "mongodb-log": "^1.0.0",
     "mkdirp": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@lucas

Upgrading mongodb-runner's version of mongodb-log to latest.

I did a lookover in MongoScope with this version to see if anything broke and nothing did.

As for "npm test", in the master branch, the testcases are failing.
