### PR TITLE
INT-958 dryrun command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,19 +46,19 @@ gulp.task('pem', function(done) {
   exec('openssl req -new -x509 -days 365 -nodes'
     + ' -out ' + out + ' -keyout ' + keyout
     + ' -subj "/C=US/ST=NY/L=NYC/CN=www.mongodb.com"', function(err) {
+    if (err) {
+      return done(err);
+    }
+
+    exec('cat ' + out + ' ' + keyout + ' > ' + pem, function(err) {
       if (err) {
         return done(err);
       }
+      console.log('- ' + out);
+      console.log('- ' + keyout);
+      console.log('- ' + pem);
 
-      exec('cat ' + out + ' ' + keyout + ' > ' + pem, function(err) {
-        if (err) {
-          return done(err);
-        }
-        console.log('- ' + out);
-        console.log('- ' + keyout);
-        console.log('- ' + pem);
-
-        done();
-      });
+      done();
     });
+  });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -354,7 +354,7 @@ function configure(opts, done) {
 var exec = module.exports = exports = function(opts, done) {
   opts.action = opts.action || 'start';
 
-  if (['dryrun', 'start', 'stop'].indexOf(opts.action) === -1) {
+  if (['install', 'start', 'stop'].indexOf(opts.action) === -1) {
     done(new Error('Unknown action.'));
     return;
   }
@@ -371,7 +371,7 @@ var exec = module.exports = exports = function(opts, done) {
       return;
     }
 
-    if (opts.action === 'dryrun') {
+    if (opts.action === 'install') {
       done();
       return;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -354,7 +354,7 @@ function configure(opts, done) {
 var exec = module.exports = exports = function(opts, done) {
   opts.action = opts.action || 'start';
 
-  if (['start', 'stop'].indexOf(opts.action) === -1) {
+  if (['dryrun', 'start', 'stop'].indexOf(opts.action) === -1) {
     done(new Error('Unknown action.'));
     return;
   }
@@ -368,6 +368,11 @@ var exec = module.exports = exports = function(opts, done) {
   ], function(err) {
     if (err) {
       done(err);
+      return;
+    }
+
+    if (opts.action === 'dryrun') {
+      done();
       return;
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,10 +2,35 @@
 
 var run = require('../');
 var kill = require('kill-mongodb');
+var mvm = require('mongodb-version-manager');
+var assert = require('assert');
 
 describe('Test Spawning MongoDB Deployments', function() {
   before(function(done) {
     kill(done);
+  });
+
+  describe('Dry Run', function() {
+    var opts = {
+      action: 'dryrun',
+      name: 'mongodb-runner-test-standalone',
+      port: 20000
+    };
+
+    it('should only invoke mongodb-version-manager', function(done) {
+      run(opts, function(err) {
+        if (err) {
+          return done(err);
+        }
+        mvm.current(function(err2, v) {
+          if (err2) {
+            return done(err2);
+          }
+          assert(v);  // ensure not null
+          done();
+        });
+      });
+    });
   });
 
   describe('Standalone', function() {

--- a/test/mongodb_cr.test.js
+++ b/test/mongodb_cr.test.js
@@ -130,23 +130,23 @@ describe.skip('Test Spawning With MONGODB-CR Enabled', function() {
 
     it('should connect and insert with good credentials to all '
       + 'members of a replicaset', function(done) {
-        verifyUserPassSuccess(opts.port, opts.auth_mechanism, opts.username, opts.password, function(err) {
-          if (err) {
-            return done(err);
+      verifyUserPassSuccess(opts.port, opts.auth_mechanism, opts.username, opts.password, function(err) {
+        if (err) {
+          return done(err);
+        }
+        verifyUserPassSuccess(opts.port + 1, opts.auth_mechanism, opts.username, opts.password, function(err2) {
+          if (err2) {
+            return done(err2);
           }
-          verifyUserPassSuccess(opts.port + 1, opts.auth_mechanism, opts.username, opts.password, function(err2) {
-            if (err2) {
-              return done(err2);
+          verifyUserPassSuccess(opts.port + 2, opts.auth_mechanism, opts.username, opts.password, function(err3) {
+            if (err3) {
+              return done(err3);
             }
-            verifyUserPassSuccess(opts.port + 2, opts.auth_mechanism, opts.username, opts.password, function(err3) {
-              if (err3) {
-                return done(err3);
-              }
-              done();
-            });
+            done();
           });
         });
       });
+    });
 
     it('should fail to connect with wrong auth mechanism', function(done) {
       verifyWrongMechanismFailure(opts.port, 'SCRAM-SHA-1', opts.username, opts.password, function(err) {

--- a/usage.txt
+++ b/usage.txt
@@ -1,4 +1,5 @@
-Usage: mongodb-runner <start|stop> [options]
+
+Usage: mongodb-runner <start|stop|dryrun> [options]
 
 Start/stop mongodb for testing.
 

--- a/usage.txt
+++ b/usage.txt
@@ -1,7 +1,7 @@
 
-Usage: mongodb-runner <start|stop|dryrun> [options]
+Usage: mongodb-runner <start|stop|install> [options]
 
-Start/stop mongodb for testing.
+Start/stop/install MongoDB for testing.
 
 Options:
   --topology=<topology>         One of standalone, replicaset, or cluster [Default: `standalone`].


### PR DESCRIPTION
The "dryrun" command invokes mongodb-version-manger but skips actual start/stop.

This is useful on CI systems to ensure that a version of mongodb is available before mocha is invoked. Specify "mongodb-runner dryrun" as the "pretest" script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/runner/67)
<!-- Reviewable:end -->
