### PR TITLE
Do not provide storageEngine argument to MongoDB < 3.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -300,6 +300,12 @@ function configure(opts, done) {
     purge: process.env.MONGODB_PURGE || true
   });
 
+  // MongoDB < 3.0 doesn't understand the storageEngine argument and
+  // will fail to start if provided!
+  if (opts.version < '3.0') {
+    delete opts.storageEngine;
+  }
+
   if (opts.topology === 'replicaset') {
     opts = defaults(opts, {
       arbiters: process.env.MONGODB_ARBITERS || 0,
@@ -364,9 +370,11 @@ var exec = module.exports = exports = function(opts, done) {
     return;
   }
 
+  opts.version = opts.version || process.env.MONGODB_VERSION;
+
   async.series([function ensureMongoInstalled(cb) {
     return mvm.use({
-      version: opts.version || process.env.MONGODB_VERSION
+      version: opts.version
     }, cb);
   },
     configure.bind(null, opts)


### PR DESCRIPTION
If you've built something like this before, you'll know that MongoDB 2.6 doesn't start when you provide the storageEngine param :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/runner/76)
<!-- Reviewable:end -->
