### PR TITLE
TSPROJ-2638: Running mongodb-runner stop command does not kill mongod process on windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -290,8 +290,8 @@ function configure(opts, done) {
   });
 
   opts = defaults(opts, {
-    logpath: untildify(process.env.MONGODB_LOGPATH || format('~/.mongodb/runner/%s.log', opts.name)),
-    pidpath: untildify(process.env.MONGODB_PIDPATH || '~/.mongodb/runner/pid'),
+    logpath: untildify(process.env.MONGODB_LOGPATH || path.normalize(format('~/.mongodb/runner/%s.log', opts.name))),
+    pidpath: untildify(process.env.MONGODB_PIDPATH || path.normalize('~/.mongodb/runner/pid')),
     port: process.env.MONGODB_PORT || 27017,
     mongodBin: process.env.MONGOD_BIN || 'mongod',
     mongosBin: process.env.MONGOS_BIN || 'mongos',

--- a/lib/index.js
+++ b/lib/index.js
@@ -201,12 +201,12 @@ var start = function(opts, done) {
         }
         if (d.event === 'started') {
           setupAuthentication(opts, function() {
-            cb(null, proc.pid);
+            cb(null, d.pid);
           });
         }
+        debug('forked proc with pid', d.pid, bin, args);
       });
       proc.on('error', done);
-      debug('forked proc with pid', proc.pid, bin, args);
       debug('waiting for error or message from forked worker...');
     }, function(pid, cb) {
       getPIDPath(opts, function(err, pidPath) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -241,16 +241,37 @@ module.exports = function(opts, done) {
     kill: false,
     purge: opts.purge
   }, function() {
-    /* eslint no-shadow:0 */
-    debug('Server started without auth');
-    if (process.send) {
-      var msg = {
-        event: 'started',
-        opts: opts
-      };
-      debug('Notifying parent process', JSON.stringify(msg, null, 2));
-      process.send(msg);
-    }
+    var url = format('mongodb://localhost:%s/test', opts.port);
+    mongodb.MongoClient.connect(url, function(err, db) {
+      if (err) {
+        return done(err);
+      }
+
+      // call serverStatus to retrieve the pid related to this instance
+      var adminDb = db.admin();
+      adminDb.serverStatus(function(serverStatusErr, info) {
+        if (serverStatusErr) {
+          return done(serverStatusErr);
+        }
+
+        /* eslint no-shadow:0 */
+        debug('Server started without auth');
+        if (process.send) {
+          var msg = {
+            event: 'started',
+            opts: opts,
+            pid: info.pid
+          };
+          debug('Notifying parent process', JSON.stringify(msg, null, 2));
+          process.send(msg);
+        }
+        db.close(function(err) {
+          if (err) {
+            done(err);
+          }
+        });
+      });
+    });
 
     if (opts.auth_mechanism !== 'MONGODB-CR' && opts.auth_mechanism !== 'SCRAM-SHA-1') {
       debug('server ready');
@@ -261,7 +282,6 @@ module.exports = function(opts, done) {
     if (opts.auth_mechanism === 'MONGODB-CR' || opts.auth_mechanism === 'SCRAM-SHA-1') {
       debug('Waiting for start...');
       setTimeout(function() {
-        var url = format('mongodb://localhost:%s/test', opts.port);
         debug('User/Pass auth enabled... connecting to MongoDB');
         mongodb.MongoClient.connect(url, function(err, db) {
           if (err) {


### PR DESCRIPTION
Currently in Windows running
```mongodb-runner stop```

does not kill the mongod pid because the node process is being terminated by the stop command rather than the mongod process.

Storing the mongod pid instead of node process pid and killing that instead fixes this issue on windows (At least for single instances, not yet tested for replicaset and sharded deployments).

Also note while this works in the current form, if the switch to mongodb-topology-manager is made, this solution may no longer be valid.