### PR TITLE
Show all mongodb-runner debug commands

### DIFF
--- a/bin/mongodb-runner.js
+++ b/bin/mongodb-runner.js
@@ -10,7 +10,7 @@ var args = require('minimist')(process.argv.slice(2), {
 });
 
 if (args.debug) {
-  process.env.DEBUG = 'mongodb-runner';
+  process.env.DEBUG = 'mongodb-runner*';
 }
 
 var run = require('../');

--- a/bin/mongodb-runner.js
+++ b/bin/mongodb-runner.js
@@ -11,7 +11,7 @@ var args = require('minimist')(process.argv.slice(2), {
 
 if (args.debug) {
   process.env.DEBUG = 'mongodb-runner*';
-}
+} 
 
 var run = require('../');
 var pkg = require('../package.json');


### PR DESCRIPTION
Fix issue for debug logging to show any names that contain mongodb-runner

For example, in mongodb-runner.js, the debug is mongodb-runner:bin which is NOT shown on the screen when `--debug` is set because it does not equal mongodb-runner.

Instead, use a wildcard so that anything mongodb-runner will be shown