### PR TITLE
Ensure we don't crash the parent process on fork

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,11 @@ var start = function(opts, done) {
   async.waterfall([
     killIfRunning.bind(null, opts), function(cb) {
       debug('forking worker `%s` with args `%j`', bin, args);
-      var proc = childProcess.fork(bin, args);
+      // Passing --inspect* flags to the forked process will crash the parent process
+      var execArgs = process.execArgv.filter((arg) => {
+        return arg.indexOf('--inspect') == -1;
+      });
+      var proc = childProcess.fork(bin, args, { execArgv: execArgs });
       proc.on('message', function onMessage(d) {
         debug('got messsage from worker', JSON.stringify(d, null, 2));
         if (!d.event) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -194,8 +194,8 @@ var start = function(opts, done) {
     killIfRunning.bind(null, opts), function(cb) {
       debug('forking worker `%s` with args `%j`', bin, args);
       // Passing --inspect* flags to the forked process will crash the parent process
-      var execArgs = process.execArgv.filter((arg) => {
-        return arg.indexOf('--inspect') == -1;
+      var execArgs = process.execArgv.filter(function(arg) {
+        return arg.indexOf('--inspect') < 0;
       });
       var proc = childProcess.fork(bin, args, { execArgv: execArgs });
       proc.on('message', function onMessage(d) {


### PR DESCRIPTION
When debugging tests using mongodb runner's mocha, having the inspect flag will lead to a fork crash as it will try to bind on the same inspector