### PR TITLE
bug: Fix "unknown --rest option"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ version: "{build}"
 
 # what combinations to test
 environment:
+  global:
+    DEBUG: '*'
   matrix:
     - nodejs_version: 10.2.1
 
@@ -20,7 +22,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
 
-build: off
+build: 'off'
 
 test_script:
   # Output useful info for debugging.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mkdirp": "^0.5.1",
     "mongodb": "^3.1.9",
     "mongodb-dbpath": "^0.0.1",
-    "mongodb-tools": "mongodb-js/mongodb-tools#b461a4c41cdf92e0c80402b2893b3b11c0ed616c",
+    "mongodb-tools": "github:mongodb-js/mongodb-tools#8da4724189dfdf7b0d02d87db14b7ce94adf6342",
     "mongodb-version-manager": "^1.3.0",
     "untildify": "^3.0.0",
     "which": "^1.2.4"


### PR DESCRIPTION
Reported by #148 

Related:

- mongodb-js/version-manager#151 (Generic linux 4.1.x tarballs now gone away)
- mongodb-js/version-manager#152 (Windows symlink fail on Appveyor)