### PR TITLE
fix: properly remove environment variable

### DIFF
--- a/mocha/after.js
+++ b/mocha/after.js
@@ -30,7 +30,7 @@ function mongodb_runner_mocha_after(opts) {
   return function(done) {
     if (process.env.MONGODB_RUNNER_MOCHA_SKIP_STOP) {
       debug('not stopping mongodb as it was not started by mocha/before');
-      process.env.MONGODB_RUNNER_MOCHA_SKIP_STOP = undefined;
+      delete process.env.MONGODB_RUNNER_MOCHA_SKIP_STOP;
       done();
       return;
     }


### PR DESCRIPTION
`process.env.FOO = undefined` sets the env var to `'undefined'`
as a string, but removing it entirely was almost certainly the
intent here.

Using `delete` here resolves that and stops Node.js from warning
about it when `--pending-deprecation` is enabled.

Refs: https://nodejs.org/api/deprecations.html#DEP0104