### PR TITLE
fix: make pid file writing work under Node.js 14.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -237,7 +237,7 @@ var start = function(opts, done) {
       },
       function(pid, pidPath, cb) {
         debug('Writing pid %d to', pid, pidPath);
-        fs.writeFile(pidPath, pid, cb);
+        fs.writeFile(pidPath, String(pid), cb);
       }
     ],
     done


### PR DESCRIPTION
Node.js 14.x expects a string or Buffer, not a plain number, as the
`data` argument of `fs.writeFile()`.